### PR TITLE
Fix usage of OCI target with insecure transport

### DIFF
--- a/pkg/client/repo/oci/oci.go
+++ b/pkg/client/repo/oci/oci.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -287,6 +288,12 @@ func (r *Repo) Has(chartName string, version string) (bool, error) {
 			Username: r.username,
 			Password: r.password,
 		}))
+	}
+
+	if r.insecure {
+		remote.DefaultTransport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
 	}
 
 	_, err = remote.Head(ref, opts...)


### PR DESCRIPTION
The `--insecure` flag wasn't respected in `oci.Repo#Has`. Now, whenever that flag is set, a `tls.Config` with `InsecureSkipVerify` set to `true` is set injected into the `DefaultTransport` used to connect to the OCI registry.

# Before

```
$ ~/dev/charts-syncer/dist/charts-syncer --insecure -c ~/dev/charts-syncer/test-config.yaml sync --latest-version-only --insecure
I0718 17:22:47.287675 3905275 sync.go:34] Using config file: "/home/max/dev/charts-syncer/test-config.yaml"
E0718 17:22:48.564152 3905275 index.go:153] unable to explore target repo to check "grafana-6.58.4" chart: failed checking remote: Get "https://localhost:8443/v2/": tls: failed to verify certificate: x509: certificate is valid for garage.garage.svc, not localhost; Get "http://localhost:8443/v2/": EOF
W0718 17:22:48.564170 3905275 index.go:120] Failed processing grafana:6.58.4 chart. The index will remain incomplete.
W0718 17:22:48.564180 3905275 sync.go:34] There were some problems loading the information of the requested charts: failed checking remote: Get "https://localhost:8443/v2/": tls: failed to verify certificate: x509: certificate is valid for garage.garage.svc, not localhost; Get "http://localhost:8443/v2/": EOF
I0718 17:22:48.564189 3905275 sync.go:49] There are no charts out of sync!
```

# After

```
$ ~/dev/charts-syncer/dist/charts-syncer --insecure -c ~/dev/charts-syncer/test-config.yaml sync --latest-version-only --insecure
I0718 17:30:51.796045 3919041 sync.go:34] Using config file: "/home/max/dev/charts-syncer/test-config.yaml"
I0718 17:30:52.060203 3919041 sync.go:47] There is 1 chart out of sync!
I0718 17:30:52.060215 3919041 sync.go:55] Syncing "grafana-6.58.4" chart...
```