### PR TITLE
feat: OCI source working with public repositories

### DIFF
--- a/pkg/client/repo/oci/oci.go
+++ b/pkg/client/repo/oci/oci.go
@@ -287,7 +287,7 @@ func (r *Repo) Fetch(chartName string, version string) (string, error) {
 			return "", errors.Annotatef(err, "fetching %s:%s chart", chartName, version)
 		}
 		// https://helm.sh/docs/topics/registries/#helm-chart-manifest
-		if t == "application/vnd.cncf.helm.chart.content.v1.tar+gzip" {
+		if isHelmChartContentLayerMediaType(string(t)) {
 			c, err := l.Compressed()
 			_, err = io.Copy(w, c)
 			if err != nil {

--- a/pkg/client/repo/oci/oci.go
+++ b/pkg/client/repo/oci/oci.go
@@ -126,9 +126,9 @@ func (r *Repo) getTagManifest(chartName, version string) (*ocispec.Manifest, err
 		}))
 	}
 	if r.insecure {
-		remote.DefaultTransport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true,
-		}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		opts = append(opts, remote.WithTransport(transport))
 	}
 
 	image, err := remote.Image(repo, opts...)
@@ -171,11 +171,6 @@ func (r *Repo) ListChartVersions(chartName string) ([]string, error) {
 	u := *r.url
 	u.Path = path.Join(u.Path, chartName)
 
-	parseOpts := []name.Option{}
-	if r.insecure {
-		parseOpts = append(parseOpts, name.Insecure)
-	}
-
 	repo, err := name.NewRepository(u.Host + u.Path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse repo %v", err)
@@ -189,9 +184,9 @@ func (r *Repo) ListChartVersions(chartName string) ([]string, error) {
 		}))
 	}
 	if r.insecure {
-		remote.DefaultTransport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true,
-		}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		opts = append(opts, remote.WithTransport(transport))
 	}
 
 	tags, err := remote.List(repo, opts...)
@@ -253,9 +248,9 @@ func (r *Repo) Fetch(chartName string, version string) (string, error) {
 		}))
 	}
 	if r.insecure {
-		remote.DefaultTransport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true,
-		}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		opts = append(opts, remote.WithTransport(transport))
 	}
 
 	img, err := remote.Image(ref, opts...)
@@ -321,6 +316,11 @@ func (r *Repo) Has(chartName string, version string) (bool, error) {
 			Username: r.username,
 			Password: r.password,
 		}))
+	}
+	if r.insecure {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		opts = append(opts, remote.WithTransport(transport))
 	}
 
 	_, err = remote.Head(ref, opts...)

--- a/pkg/client/repo/oci/oci.go
+++ b/pkg/client/repo/oci/oci.go
@@ -105,11 +105,6 @@ func (r *Repo) List() ([]string, error) {
 
 // getTagManifest returns the manifests of a published tag
 func (r *Repo) getTagManifest(chartName, version string) (*ocispec.Manifest, error) {
-	parseOpts := []name.Option{}
-	if r.insecure {
-		parseOpts = append(parseOpts, name.Insecure)
-	}
-
 	u := *r.url
 	u.Path = path.Join(u.Path, "/", chartName)
 
@@ -228,14 +223,8 @@ func (r *Repo) Fetch(chartName string, version string) (string, error) {
 		return r.cache.Path(id), nil
 	}
 
-	parseOpts := []name.Option{}
-	if r.insecure {
-		parseOpts = append(parseOpts, name.Insecure)
-	}
-
 	ref, err := name.ParseReference(
-		fmt.Sprintf("%s:%s", path.Join(strings.TrimPrefix(r.url.String(), fmt.Sprintf("%s://", r.url.Scheme)), chartName), version),
-		parseOpts...)
+		fmt.Sprintf("%s:%s", path.Join(strings.TrimPrefix(r.url.String(), fmt.Sprintf("%s://", r.url.Scheme)), chartName), version))
 	if err != nil {
 		return "", errors.Errorf("failed parsing OCI reference: %s", err)
 	}
@@ -298,14 +287,8 @@ func (r *Repo) Fetch(chartName string, version string) (string, error) {
 
 // Has checks if a repo has a specific chart
 func (r *Repo) Has(chartName string, version string) (bool, error) {
-	parseOpts := []name.Option{}
-	if r.insecure {
-		parseOpts = append(parseOpts, name.Insecure)
-	}
-
 	ref, err := name.ParseReference(
-		fmt.Sprintf("%s:%s", path.Join(strings.TrimPrefix(r.url.String(), fmt.Sprintf("%s://", r.url.Scheme)), chartName), version),
-		parseOpts...)
+		fmt.Sprintf("%s:%s", path.Join(strings.TrimPrefix(r.url.String(), fmt.Sprintf("%s://", r.url.Scheme)), chartName), version))
 	if err != nil {
 		return false, errors.Errorf("failed parsing OCI reference: %s", err)
 	}

--- a/pkg/client/repo/oci/oci.go
+++ b/pkg/client/repo/oci/oci.go
@@ -105,13 +105,13 @@ func (r *Repo) List() ([]string, error) {
 
 // getTagManifest returns the manifests of a published tag
 func (r *Repo) getTagManifest(chartName, version string) (*ocispec.Manifest, error) {
-	u := *r.url
-	u.Path = path.Join(u.Path, chartName)
-
 	parseOpts := []name.Option{}
 	if r.insecure {
 		parseOpts = append(parseOpts, name.Insecure)
 	}
+
+	u := *r.url
+	u.Path = path.Join(u.Path, "/", chartName)
 
 	repo, err := name.ParseReference(u.Host + u.Path + ":" + version)
 	if err != nil {
@@ -169,7 +169,7 @@ func (r *Repo) ListChartVersions(chartName string) ([]string, error) {
 	}
 
 	u := *r.url
-	u.Path = path.Join(u.Path, chartName)
+	u.Path = path.Join(u.Path, "/", chartName)
 
 	repo, err := name.NewRepository(u.Host + u.Path)
 	if err != nil {

--- a/pkg/client/repo/oci/oci.go
+++ b/pkg/client/repo/oci/oci.go
@@ -204,18 +204,6 @@ func (r *Repo) ListChartVersions(chartName string) ([]string, error) {
 	return chartTags, nil
 }
 
-// GetDownloadURL returns the URL to download a chart
-func (r *Repo) GetDownloadURL(name string, version string) (string, error) {
-	digest, err := r.getChartDigest(name, version)
-	if err != nil {
-		return "", errors.Annotatef(err, "obtaining chart digest")
-	}
-	u := *r.url
-	// Form API endpoint URL from repository URL
-	u.Path = path.Join("v2", u.Path, name, "blobs", digest)
-	return u.String(), nil
-}
-
 // Fetch fetches a chart
 func (r *Repo) Fetch(chartName string, version string) (string, error) {
 	id := fmt.Sprintf("%s-%s.tgz", chartName, version)

--- a/pkg/client/repo/oci/oci_test.go
+++ b/pkg/client/repo/oci/oci_test.go
@@ -1,9 +1,7 @@
 package oci_test
 
 import (
-	"net/url"
 	"os"
-	"path"
 	"reflect"
 	"sort"
 	"testing"
@@ -147,23 +145,6 @@ func TestReload(t *testing.T) {
 	err := c.Reload()
 	if err.Error() != expectedError {
 		t.Errorf("unexpected error message. got: %q, want: %q", err.Error(), expectedError)
-	}
-}
-
-func TestGetDownloadURL(t *testing.T) {
-	c := oci.PrepareHttpServer(t, ociRepo)
-	u, err := url.Parse(ociRepo.Url)
-	if err != nil {
-		t.Fatal(err)
-	}
-	u.Path = path.Join("v2", u.Path, "kafka/blobs/sha256:11e974d88391a39e4dd6d7d6c4350b237b1cca1bf32f2074bba41109eaa5f438")
-	want := u.String()
-	got, err := c.GetDownloadURL("kafka", "12.2.1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got != want {
-		t.Errorf("wrong download URL. got: %v, want: %v", got, want)
 	}
 }
 

--- a/pkg/client/repo/oci/oci_test.go
+++ b/pkg/client/repo/oci/oci_test.go
@@ -29,8 +29,18 @@ var (
 )
 
 func TestFetch(t *testing.T) {
-	c := oci.PrepareHttpServer(t, ociRepo)
-	chartPath, err := c.Fetch("kafka", "12.2.1")
+	oci.PrepareOciServer(t, ociRepo)
+	c := oci.PrepareTest(t, ociRepo)
+
+	chartMetadata := &chart.Metadata{
+		Name:    "apache",
+		Version: "7.3.15",
+	}
+	if err := c.Upload("../../../../testdata/apache-7.3.15.tgz", chartMetadata); err != nil {
+		t.Fatal(err)
+	}
+
+	chartPath, err := c.Fetch("apache", "7.3.15")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +78,9 @@ func TestHas(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
-	c := oci.PrepareHttpServer(t, ociRepo)
+	oci.PrepareOciServer(t, ociRepo)
+	c := oci.PrepareTest(t, ociRepo)
+
 	want := []string{}
 	got, err := c.List()
 	if err != nil {
@@ -82,9 +94,18 @@ func TestList(t *testing.T) {
 }
 
 func TestListChartVersions(t *testing.T) {
-	c := oci.PrepareHttpServer(t, ociRepo)
-	want := []string{"12.2.1"}
-	got, err := c.ListChartVersions("kafka")
+	oci.PrepareOciServer(t, ociRepo)
+	c := oci.PrepareTest(t, ociRepo)
+	chartMetadata := &chart.Metadata{
+		Name:    "apache",
+		Version: "7.3.15",
+	}
+	if err := c.Upload("../../../../testdata/apache-7.3.15.tgz", chartMetadata); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"7.3.15"}
+	got, err := c.ListChartVersions("apache")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,12 +117,22 @@ func TestListChartVersions(t *testing.T) {
 }
 
 func TestGetChartDetails(t *testing.T) {
-	c := oci.PrepareHttpServer(t, ociRepo)
+	oci.PrepareOciServer(t, ociRepo)
+	c := oci.PrepareTest(t, ociRepo)
+
+	chartMetadata := &chart.Metadata{
+		Name:    "apache",
+		Version: "7.3.15",
+	}
+	if err := c.Upload("../../../../testdata/apache-7.3.15.tgz", chartMetadata); err != nil {
+		t.Fatal(err)
+	}
+
 	want := types.ChartDetails{
 		PublishedAt: time.Now(),
-		Digest:      "sha256:11e974d88391a39e4dd6d7d6c4350b237b1cca1bf32f2074bba41109eaa5f438",
+		Digest:      "sha256:a51babb4da1164f35b0a3e8050a24c387db4dba46dbb96b78ef0c4a658efeb00",
 	}
-	got, err := c.GetChartDetails("kafka", "12.2.1")
+	got, err := c.GetChartDetails("apache", "7.3.15")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Closes #182 

Rewrites the OCI`Fetch` function to use the `go-containerregistry` package instead simple a simple GET that was in `FetchAndCache`.
Since the code is OCI specific I moved it into the `oci.go` and left the `FetchAndCache` untouched.

This makes repositories like GHCR.io and Docker Hub work since they require an oauth flow which is now done by the package.

Has the the fix of #186 implemented as well (for the `Fetch` and `ListChartVersions` function, that PR is still relevant for the `Has`). Most of the `go-containerregistry` logic was taken from other functions already using the package.

This isn't yet ready for production I think, I need some feedback/input on:
* error messages and general error management
*  is the logic around `cache.invalidate` still correct? Compared to the `FetchAndCache` it replaces ([link](https://github.com/bitnami/charts-syncer/blob/master/internal/utils/utils.go#L379))

General feedback is of course welcome! I am not as fluent in Go as I would like ;)

The `FetchAndCache` funtion is now only used by helm classic and could be moved into there to instead of the shared utils.

### Tests 

Test file:
```yaml
---
source:
  repo:
    kind: OCI
    disableChartsIndex: true
    url: https://registry.hub.docker.com/bitnamicharts
target:
  repo:
    kind: OCI
    # docker run -d -p 8080:5000 --restart=always --name registry registry:2
    url: http://localhost:8080
charts:
  - rabbitmq-cluster-operator
```

Current 0.20.1 version:
```console
# charts-syncer -c test.yaml sync
I1103 15:04:12.918464       1 sync.go:34] Using config file: "test.yaml"
W1103 15:04:13.512572       1 sync.go:34] There were some problems loading the information of the requested charts: unexpected response — 401 "Unauthorized", {"errors":[{"code":"UNAUTHORIZED","message":"authentication required","detail":[{"Type":"repository","Class":"","Name":"bitnamicharts/rabbitmq-cluster-operator","Action":"pull"}]}]}
 — from https://registry.hub.docker.com/v2/bitnamicharts/rabbitmq-cluster-operator/tags/list
I1103 15:04:13.513631       1 sync.go:49] There are no charts out of sync!
```

With this PR:
```console
# charts-syncer -c test.yaml sync
I1103 16:05:59.304245   37791 sync.go:34] Using config file: "test.yaml"
I1103 16:06:43.965725   37791 sync.go:45] There are 55 charts out of sync!
I1103 16:06:43.965748   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.2.7" chart...
I1103 16:06:44.435869   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.1.1" chart...
I1103 16:06:44.664391   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.1.5" chart...
I1103 16:06:44.876668   37791 sync.go:55] Syncing "common-2.13.2" chart...
I1103 16:06:45.085246   37791 sync.go:55] Syncing "common-2.10.0" chart...
I1103 16:06:45.288925   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.2.1" chart...
I1103 16:06:45.656256   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.2.8" chart...
I1103 16:06:46.036875   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.2.10" chart...
I1103 16:06:46.421172   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.2.3" chart...
I1103 16:06:46.806111   37791 sync.go:55] Syncing "common-2.11.1" chart...
I1103 16:06:46.887843   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.1.3" chart...
I1103 16:06:47.173408   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.2.0" chart...
I1103 16:06:47.529619   37791 sync.go:55] Syncing "common-2.4.0" chart...
I1103 16:06:47.584617   37791 sync.go:55] Syncing "common-2.2.4" chart...
I1103 16:06:47.626355   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.2.9" chart...
I1103 16:06:48.016706   37791 sync.go:55] Syncing "common-2.6.0" chart...
I1103 16:06:48.179834   37791 sync.go:55] Syncing "common-2.8.0" chart...
I1103 16:06:48.268363   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.2.2" chart...
I1103 16:06:48.817650   37791 sync.go:55] Syncing "common-2.12.0" chart...
I1103 16:06:48.959972   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.1.2" chart...
I1103 16:06:49.166723   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.2.4" chart...
I1103 16:06:49.539003   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.2.5" chart...
I1103 16:06:49.924295   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.1.4" chart...
I1103 16:06:50.282163   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.1.6" chart...
I1103 16:06:50.547488   37791 sync.go:55] Syncing "common-2.2.5" chart...
I1103 16:06:50.633203   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.2.6" chart...
I1103 16:06:50.852886   37791 sync.go:55] Syncing "common-2.9.0" chart...
I1103 16:06:50.951787   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.8.7" chart...
I1103 16:06:51.126404   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.8.8" chart...
I1103 16:06:51.510595   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.10.0" chart...
I1103 16:06:51.669309   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.8.6" chart...
I1103 16:06:51.767081   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.8.9" chart...
I1103 16:06:51.939000   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.9.0" chart...
I1103 16:06:52.167144   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.7.3" chart...
I1103 16:06:52.396091   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.7.4" chart...
I1103 16:06:52.776244   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.8.0" chart...
I1103 16:06:52.999721   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.8.1" chart...
I1103 16:06:53.263030   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.4.2" chart...
I1103 16:06:53.476549   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.4.1" chart...
I1103 16:06:53.741953   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.3.1" chart...
I1103 16:06:54.129934   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.6.5" chart...
I1103 16:06:54.415714   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.5.0" chart...
I1103 16:06:54.653070   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.6.0" chart...
I1103 16:06:54.924667   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.6.1" chart...
I1103 16:06:55.083649   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.6.4" chart...
I1103 16:06:55.357564   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.6.2" chart...
I1103 16:06:55.669050   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.6.3" chart...
I1103 16:06:55.868448   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.6.7" chart...
I1103 16:06:56.039458   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.6.6" chart...
I1103 16:06:56.201536   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.8.2" chart...
I1103 16:06:56.585707   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.8.3" chart...
I1103 16:06:56.841684   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.3.2" chart...
I1103 16:06:57.124429   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.7.2" chart...
I1103 16:06:57.406869   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.7.1" chart...
I1103 16:06:57.592433   37791 sync.go:55] Syncing "rabbitmq-cluster-operator-3.7.0" chart...
```