### PR TITLE
fix: replace deprecated iotil functions with os/io equivalents

### DIFF
--- a/internal/cache/cachedisk/cachedisk.go
+++ b/internal/cache/cachedisk/cachedisk.go
@@ -2,7 +2,6 @@ package cachedisk
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -65,7 +64,7 @@ func (c *Cache) Read(w io.Writer, filename string) error {
 	if !c.Has(filename) {
 		return errors.NotFoundf("cache { id:%s, filename:%s }", c.id, filename)
 	}
-	data, err := ioutil.ReadFile(c.Path(filename))
+	data, err := os.ReadFile(c.Path(filename))
 	if err != nil {
 		return errors.Annotatef(err, "reading %q from the cache", filename)
 	}

--- a/internal/chart/chart.go
+++ b/internal/chart/chart.go
@@ -2,7 +2,7 @@ package chart
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -29,7 +29,7 @@ func updateValuesFile(valuesFile string, targetRepo *api.Target) error {
 
 // updateContainerImageRepository updates the container repository in a values.yaml file.
 func updateContainerImageRepository(valuesFile string, target *api.Target) error {
-	values, err := ioutil.ReadFile(valuesFile)
+	values, err := os.ReadFile(valuesFile)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -37,7 +37,7 @@ func updateContainerImageRepository(valuesFile string, target *api.Target) error
 	if len(submatch) > 0 {
 		replaceLine := fmt.Sprintf("%s%s%s", submatch[1], target.ContainerRepository, submatch[3])
 		newContents := repositoryRegex.ReplaceAllString(string(values), replaceLine)
-		err = ioutil.WriteFile(valuesFile, []byte(newContents), 0)
+		err = os.WriteFile(valuesFile, []byte(newContents), 0)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -47,7 +47,7 @@ func updateContainerImageRepository(valuesFile string, target *api.Target) error
 
 // updateContainerImageRegistry updates the container registry in a values.yaml file.
 func updateContainerImageRegistry(valuesFile string, target *api.Target) error {
-	values, err := ioutil.ReadFile(valuesFile)
+	values, err := os.ReadFile(valuesFile)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -55,7 +55,7 @@ func updateContainerImageRegistry(valuesFile string, target *api.Target) error {
 	if len(submatch) > 0 {
 		replaceLine := fmt.Sprintf("%s%s%s", submatch[1], target.ContainerRegistry, submatch[3])
 		newContents := registryRegex.ReplaceAllString(string(values), replaceLine)
-		err = ioutil.WriteFile(valuesFile, []byte(newContents), 0)
+		err = os.WriteFile(valuesFile, []byte(newContents), 0)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -65,7 +65,7 @@ func updateContainerImageRegistry(valuesFile string, target *api.Target) error {
 
 // updateReadmeFile performs some substitutions to a given README.md file.
 func updateReadmeFile(readmeFile, sourceURL, targetURL, chartName, repoName string) error {
-	readme, err := ioutil.ReadFile(readmeFile)
+	readme, err := os.ReadFile(readmeFile)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -84,5 +84,5 @@ func updateReadmeFile(readmeFile, sourceURL, targetURL, chartName, repoName stri
 		replaceText := fmt.Sprintf("%s%s/%s%s", submatch[1], repoName, chartName, submatch[3])
 		newContent = regex.ReplaceAllString(newContent, replaceText)
 	}
-	return errors.Trace(ioutil.WriteFile(readmeFile, []byte(newContent), 0))
+	return errors.Trace(os.WriteFile(readmeFile, []byte(newContent), 0))
 }

--- a/internal/chart/chart_test.go
+++ b/internal/chart/chart_test.go
@@ -1,7 +1,6 @@
 package chart
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -66,7 +65,7 @@ volumePermissions:
     repository: test/repo/custom-base-image
     tag: r0`
 	// Create temporary working directory
-	testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
+	testTmpDir, err := os.MkdirTemp("", "charts-syncer-tests")
 	if err != nil {
 		t.Fatalf("error creating temporary: %s", testTmpDir)
 	}
@@ -74,13 +73,13 @@ volumePermissions:
 	destValuesFilePath := path.Join(testTmpDir, ValuesFilename)
 
 	// Write file
-	err = ioutil.WriteFile(destValuesFilePath, []byte(originalValues), 0644)
+	err = os.WriteFile(destValuesFilePath, []byte(originalValues), 0644)
 	if err != nil {
 		t.Fatalf("error writting destination file")
 	}
 
 	updateValuesFile(destValuesFilePath, target)
-	valuesFile, err := ioutil.ReadFile(destValuesFilePath)
+	valuesFile, err := os.ReadFile(destValuesFilePath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +111,7 @@ $ helm install my-release mytestrepo/ghost
 The above parameters map to the env variables defined in [bitnami/ghost](http://github.com/bitnami/bitnami-docker-ghost).
 	`
 	// Create temporary working directory
-	testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
+	testTmpDir, err := os.MkdirTemp("", "charts-syncer-tests")
 	if err != nil {
 		t.Fatalf("error creating temporary: %s", testTmpDir)
 	}
@@ -120,13 +119,13 @@ The above parameters map to the env variables defined in [bitnami/ghost](http://
 	destValuesFilePath := path.Join(testTmpDir, ReadmeFilename)
 
 	// Write file
-	err = ioutil.WriteFile(destValuesFilePath, []byte(originalValues), 0644)
+	err = os.WriteFile(destValuesFilePath, []byte(originalValues), 0644)
 	if err != nil {
 		t.Fatalf("error writting destination file")
 	}
 
 	updateReadmeFile(destValuesFilePath, "https://charts.bitnami.com/bitnami", "https://my-new-chart-repo.com", "ghost", "mytestrepo")
-	readmeFile, err := ioutil.ReadFile(destValuesFilePath)
+	readmeFile, err := os.ReadFile(destValuesFilePath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/chart/dependency.go
+++ b/internal/chart/dependency.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -54,7 +53,7 @@ func GetChartLock(chartPath string) (*chart.Lock, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	lockContent, err := ioutil.ReadFile(lockFilePath)
+	lockContent, err := os.ReadFile(lockFilePath)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -68,7 +67,7 @@ func GetChartLock(chartPath string) (*chart.Lock, error) {
 // GetChartDependencies returns the chart chart.Dependencies from a chart in tgz format.
 func GetChartDependencies(filepath string, name string) ([]*chart.Dependency, error) {
 	// Create temporary working directory
-	chartPath, err := ioutil.TempDir("", "charts-syncer")
+	chartPath, err := os.MkdirTemp("", "charts-syncer")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -181,7 +180,7 @@ func BuildDependencies(chartPath string, r client.ChartsReader, sourceRepo, targ
 // For helm v3 dependency management
 func updateChartMetadataFile(chartPath string, lock *chart.Lock, sourceRepo, targetRepo *api.Repo) error {
 	chartFile := path.Join(chartPath, ChartFilename)
-	chartYamlContent, err := ioutil.ReadFile(chartFile)
+	chartYamlContent, err := os.ReadFile(chartFile)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -216,7 +215,7 @@ func updateChartMetadataFile(chartPath string, lock *chart.Lock, sourceRepo, tar
 // For helm v2 dependency management
 func updateRequirementsFile(chartPath string, lock *chart.Lock, sourceRepo, targetRepo *api.Repo) error {
 	requirementsFile := path.Join(chartPath, RequirementsFilename)
-	requirements, err := ioutil.ReadFile(requirementsFile)
+	requirements, err := os.ReadFile(requirementsFile)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -285,7 +284,7 @@ func writeChartFile(dest string, v interface{}) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return ioutil.WriteFile(dest, data, 0644)
+	return os.WriteFile(dest, data, 0644)
 }
 
 // hashDeps generates a hash of the dependencies.

--- a/internal/chart/dependency_test.go
+++ b/internal/chart/dependency_test.go
@@ -2,7 +2,6 @@ package chart
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -17,7 +16,7 @@ import (
 func newChartPath(t *testing.T, file string, name string) string {
 	t.Helper()
 
-	testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
+	testTmpDir, err := os.MkdirTemp("", "charts-syncer-tests")
 	if err != nil {
 		t.Fatalf("error creating temporary: %s", testTmpDir)
 	}
@@ -94,7 +93,7 @@ func TestUpdateRequirementsFile(t *testing.T) {
 	}
 
 	// Test requirements file
-	requirements, err := ioutil.ReadFile(requirementsFile)
+	requirements, err := os.ReadFile(requirementsFile)
 	if err != nil {
 		t.Fatalf("error reading updated %s file", requirementsFile)
 	}
@@ -114,7 +113,7 @@ func TestUpdateRequirementsFile(t *testing.T) {
 
 	// Test requirements lock file
 	requirementsFileLock := path.Join(chartPath, RequirementsLockFilename)
-	requirementsLock, err := ioutil.ReadFile(requirementsFileLock)
+	requirementsLock, err := os.ReadFile(requirementsFileLock)
 	if err != nil {
 		t.Fatalf("error reading updated %s file", requirementsFileLock)
 	}
@@ -142,13 +141,13 @@ func TestUpdateChartMetadataFile(t *testing.T) {
 		},
 	}
 
-	testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
+	testTmpDir, err := os.MkdirTemp("", "charts-syncer-tests")
 	if err != nil {
 		t.Fatalf("error creating temporary: %s", testTmpDir)
 	}
 	defer os.RemoveAll(testTmpDir)
 
-	sourceFile, err := ioutil.ReadFile("../../testdata/kafka-chart.yaml")
+	sourceFile, err := os.ReadFile("../../testdata/kafka-chart.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +157,7 @@ func TestUpdateChartMetadataFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ioutil.WriteFile(chartFile, sourceFile, 0644)
+	err = os.WriteFile(chartFile, sourceFile, 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +167,7 @@ func TestUpdateChartMetadataFile(t *testing.T) {
 	}
 
 	// Test Chart.yaml file
-	chartFileContent, err := ioutil.ReadFile(chartFile)
+	chartFileContent, err := os.ReadFile(chartFile)
 	if err != nil {
 		t.Fatalf("error reading updated %s file", chartFile)
 	}
@@ -188,7 +187,7 @@ func TestUpdateChartMetadataFile(t *testing.T) {
 
 	// Test Chart.lock file
 	chartFileLock := path.Join(chartPath, ChartLockFilename)
-	chartLock, err := ioutil.ReadFile(chartFileLock)
+	chartLock, err := os.ReadFile(chartFileLock)
 	if err != nil {
 		t.Fatalf("error reading updated %s file", chartFileLock)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,8 +3,8 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/bitnami-labs/charts-syncer/api"
@@ -130,7 +130,7 @@ func setAuthentication(source *api.Source, target *api.Target) error {
 
 // yamlToProto unmarshals `path` into the provided proto message
 func yamlToProto(path string, v proto.Message) error {
-	yamlBytes, err := ioutil.ReadFile(path)
+	yamlBytes, err := os.ReadFile(path)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/indexer/oci.go
+++ b/internal/indexer/oci.go
@@ -3,7 +3,6 @@ package indexer
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"net/url"
 	"os"
 
@@ -33,8 +32,7 @@ type OciIndexerOpt func(opts *ociIndexerOpts)
 // WithIndexRef configures the charts index OCI reference instead of letting the library
 // using the default host/index:latest one.
 //
-// 	opt := WithIndexRef("my.oci.domain/index:prod")
-//
+//	opt := WithIndexRef("my.oci.domain/index:prod")
 func WithIndexRef(r string) OciIndexerOpt {
 	return func(opts *ociIndexerOpts) {
 		opts.reference = r
@@ -43,8 +41,7 @@ func WithIndexRef(r string) OciIndexerOpt {
 
 // WithBasicAuth configures basic authentication for the OCI host
 //
-// 	opt := WithBasicAuth("user", "pass")
-//
+//	opt := WithBasicAuth("user", "pass")
 func WithBasicAuth(user, pass string) OciIndexerOpt {
 	return func(opts *ociIndexerOpts) {
 		opts.username = user
@@ -54,8 +51,7 @@ func WithBasicAuth(user, pass string) OciIndexerOpt {
 
 // WithInsecure configures insecure connection
 //
-// 	opt := WithInsecure()
-//
+//	opt := WithInsecure()
 func WithInsecure() OciIndexerOpt {
 	return func(opts *ociIndexerOpts) {
 		opts.insecure = true
@@ -64,8 +60,7 @@ func WithInsecure() OciIndexerOpt {
 
 // WithHost configures the OCI host
 //
-// 	opt := WithHost("my.oci.domain")
-//
+//	opt := WithHost("my.oci.domain")
 func WithHost(h string) OciIndexerOpt {
 	return func(opts *ociIndexerOpts) {
 		opts.url = h
@@ -128,7 +123,7 @@ func (ind *ociIndexer) Get(ctx context.Context) (idx *api.Index, e error) {
 		return nil, errors.Wrapf(err, "unable to download index")
 	}
 
-	data, err := ioutil.ReadFile(indexFile)
+	data, err := os.ReadFile(indexFile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to read index file")
 	}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -101,7 +100,7 @@ func downloadIndex(repo *api.Repo) (string, error) {
 	}
 
 	// Create the file
-	out, err := ioutil.TempFile("", "index.*.yaml")
+	out, err := os.CreateTemp("", "index.*.yaml")
 	if err != nil {
 		klog.Fatal(err)
 	}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -65,7 +64,7 @@ func TestDownloadIndex(t *testing.T) {
 func TestUntar(t *testing.T) {
 	filepath := "../../testdata/apache-7.3.15.tgz"
 	// Create temporary working directory
-	testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
+	testTmpDir, err := os.MkdirTemp("", "charts-syncer-tests")
 	if err != nil {
 		t.Fatalf("error creating temporary: %s", testTmpDir)
 	}

--- a/pkg/client/repo/chartmuseum/chartmuseum_test.go
+++ b/pkg/client/repo/chartmuseum/chartmuseum_test.go
@@ -3,7 +3,6 @@ package chartmuseum_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -36,7 +35,7 @@ func prepareTest(t *testing.T) (*chartmuseum.Repo, error) {
 	t.Helper()
 
 	// Create temp folder and copy index.yaml
-	dstTmp, err := ioutil.TempDir("", "charts-syncer-tests-index-fake")
+	dstTmp, err := os.MkdirTemp("", "charts-syncer-tests-index-fake")
 	if err != nil {
 		t.Fatalf("error creating temporary folder: %v", err)
 	}
@@ -52,17 +51,17 @@ func prepareTest(t *testing.T) (*chartmuseum.Repo, error) {
 
 	// Replace placeholder
 	u := fmt.Sprintf("%s%s", tester.GetURL(), "/charts")
-	index, err := ioutil.ReadFile(dstIndex)
+	index, err := os.ReadFile(dstIndex)
 	if err != nil {
 		t.Fatal(err)
 	}
 	newContents := strings.Replace(string(index), "TEST_PLACEHOLDER", u, -1)
-	if err = ioutil.WriteFile(dstIndex, []byte(newContents), 0); err != nil {
+	if err = os.WriteFile(dstIndex, []byte(newContents), 0); err != nil {
 		t.Fatal(err)
 	}
 
 	// Define cache dir
-	cacheDir, err := ioutil.TempDir("", "client")
+	cacheDir, err := os.MkdirTemp("", "client")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/client/repo/core.go
+++ b/pkg/client/repo/core.go
@@ -1,7 +1,7 @@
 package repo
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/juju/errors"
 
@@ -27,7 +27,7 @@ func NewClient(repo *api.Repo, opts ...types.Option) (client.ChartsReaderWriter,
 	// Define cache dir if it hasn't been provided
 	cacheDir := copts.GetCache()
 	if cacheDir == "" {
-		dir, err := ioutil.TempDir("", "client")
+		dir, err := os.MkdirTemp("", "client")
 		if err != nil {
 			return nil, errors.Annotatef(err, "creating temporary dir")
 		}

--- a/pkg/client/repo/harbor/harbor_test.go
+++ b/pkg/client/repo/harbor/harbor_test.go
@@ -3,7 +3,6 @@ package harbor_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -37,7 +36,7 @@ func prepareTest(t *testing.T) (*harbor.Repo, error) {
 	t.Helper()
 
 	// Create temp folder and copy index.yaml
-	dstTmp, err := ioutil.TempDir("", "charts-syncer-tests-index-fake")
+	dstTmp, err := os.MkdirTemp("", "charts-syncer-tests-index-fake")
 	if err != nil {
 		t.Fatalf("error creating temporary folder: %v", err)
 	}
@@ -53,17 +52,17 @@ func prepareTest(t *testing.T) (*harbor.Repo, error) {
 
 	// Replace placeholder
 	u := fmt.Sprintf("%s%s", tester.GetURL(), "/chartrepo/library/charts")
-	index, err := ioutil.ReadFile(dstIndex)
+	index, err := os.ReadFile(dstIndex)
 	if err != nil {
 		t.Fatal(err)
 	}
 	newContents := strings.Replace(string(index), "TEST_PLACEHOLDER", u, -1)
-	if err = ioutil.WriteFile(dstIndex, []byte(newContents), 0); err != nil {
+	if err = os.WriteFile(dstIndex, []byte(newContents), 0); err != nil {
 		t.Fatal(err)
 	}
 
 	// Define cache dir
-	cacheDir, err := ioutil.TempDir("", "client")
+	cacheDir, err := os.MkdirTemp("", "client")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/client/repo/helmclassic/helmclassic.go
+++ b/pkg/client/repo/helmclassic/helmclassic.go
@@ -2,7 +2,6 @@ package helmclassic
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -62,7 +61,7 @@ var reloadIndex = func(r *Repo) error {
 
 	// Create the index.yaml file to use the helm Go library, which does not
 	// expose a Loader from bytes.
-	f, err := ioutil.TempFile("", "index.*.yaml")
+	f, err := os.CreateTemp("", "index.*.yaml")
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/client/repo/helmclassic/helmclassic_test.go
+++ b/pkg/client/repo/helmclassic/helmclassic_test.go
@@ -2,7 +2,6 @@ package helmclassic_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -33,7 +32,7 @@ func prepareTest(t *testing.T, indexFileName string) *helmclassic.Repo {
 	t.Helper()
 
 	// Create temp folder and copy index.yaml
-	dstTmp, err := ioutil.TempDir("", "charts-syncer-tests-index-fake")
+	dstTmp, err := os.MkdirTemp("", "charts-syncer-tests-index-fake")
 	if err != nil {
 		t.Fatalf("error creating temporary folder: %v", err)
 	}
@@ -50,17 +49,17 @@ func prepareTest(t *testing.T, indexFileName string) *helmclassic.Repo {
 
 	// Replace placeholder
 	u := fmt.Sprintf("%s%s", tester.GetURL(), "/charts")
-	index, err := ioutil.ReadFile(dstIndex)
+	index, err := os.ReadFile(dstIndex)
 	if err != nil {
 		t.Fatal(err)
 	}
 	newContents := strings.Replace(string(index), "TEST_PLACEHOLDER", u, -1)
-	if err = ioutil.WriteFile(dstIndex, []byte(newContents), 0); err != nil {
+	if err = os.WriteFile(dstIndex, []byte(newContents), 0); err != nil {
 		t.Fatal(err)
 	}
 
 	// Define cache dir
-	cacheDir, err := ioutil.TempDir("", "client")
+	cacheDir, err := os.MkdirTemp("", "client")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/client/repo/helmclassic/helmclassictester.go
+++ b/pkg/client/repo/helmclassic/helmclassictester.go
@@ -6,10 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -141,7 +141,7 @@ func (rt *RepoTester) GetIndex(w http.ResponseWriter, r *http.Request, emptyInde
 	if emptyIndex {
 		indexFile = filepath.Join(testdataPath, "empty-index.yaml")
 	}
-	index, err := ioutil.ReadFile(indexFile)
+	index, err := os.ReadFile(indexFile)
 	if err != nil {
 		rt.t.Fatal(err)
 	}
@@ -155,7 +155,7 @@ func (rt *RepoTester) GetChartPackage(w http.ResponseWriter, r *http.Request, ch
 	testdataPath := path.Join(path.Dir(filename), "../../../../testdata")
 	// Get chart from testdata folder
 	chartPackageFile := path.Join(testdataPath, "charts", chartPackageName)
-	chartPackage, err := ioutil.ReadFile(chartPackageFile)
+	chartPackage, err := os.ReadFile(chartPackageFile)
 	if err != nil {
 		rt.t.Fatal(err)
 	}
@@ -215,7 +215,7 @@ func chartMetadataFromTGZ(r io.Reader) (*Metadata, error) {
 		}
 	}
 
-	data, err := ioutil.ReadAll(t)
+	data, err := io.ReadAll(t)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/repo/local/local.go
+++ b/pkg/client/repo/local/local.go
@@ -2,7 +2,6 @@ package local
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -102,13 +101,13 @@ func (r *Repo) Upload(filepath string, metadata *chart.Metadata) error {
 		}
 	}
 
-	input, err := ioutil.ReadFile(filepath)
+	input, err := os.ReadFile(filepath)
 	if err != nil {
 		return errors.Annotatef(err, "reading %q", filepath)
 	}
 
 	out := path.Join(r.dir, fmt.Sprintf("%s-%s.tgz", name, version))
-	if err := ioutil.WriteFile(out, input, 0644); err != nil {
+	if err := os.WriteFile(out, input, 0644); err != nil {
 		return errors.Annotatef(err, "creating %q", out)
 	}
 

--- a/pkg/client/repo/oci/oci.go
+++ b/pkg/client/repo/oci/oci.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -130,7 +130,7 @@ func (r *Repo) getTagManifest(name, version string) (*ocispec.Manifest, error) {
 	defer resp.Body.Close()
 
 	status := resp.StatusCode
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Errorf("unexpected response — %d %q — from %s", status, http.StatusText(status), u.String())
 	}
@@ -190,7 +190,7 @@ func (r *Repo) ListChartVersions(name string) ([]string, error) {
 	}
 	defer resp.Body.Close()
 	status := resp.StatusCode
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Errorf("unexpected response — %d %q — from %s", status, http.StatusText(status), u.String())
 	}
@@ -328,7 +328,7 @@ func (r *Repo) Upload(file string, metadata *chart.Metadata) error {
 	// Preparing layers
 	fileName := filepath.Base(file)
 	fileMediaType := HelmChartContentLayerMediaType
-	fileBuffer, err := ioutil.ReadFile(file)
+	fileBuffer, err := os.ReadFile(file)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/client/repo/oci/ocitester.go
+++ b/pkg/client/repo/oci/ocitester.go
@@ -3,7 +3,6 @@ package oci
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -87,7 +86,7 @@ func PrepareTest(t *testing.T, ociRepo *api.Repo) *Repo {
 	t.Helper()
 
 	// Define cache dir
-	cacheDir, err := ioutil.TempDir("", "client")
+	cacheDir, err := os.MkdirTemp("", "client")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -227,7 +226,7 @@ func (rt *RepoTester) GetTagManifest(w http.ResponseWriter, r *http.Request, nam
 	// Get oci manifest from testdata folder
 	manifestFileName := fmt.Sprintf("%s-%s-oci-manifest.json", name, version)
 	manifestFile := filepath.Join(testdataPath, manifestFileName)
-	manifest, err := ioutil.ReadFile(manifestFile)
+	manifest, err := os.ReadFile(manifestFile)
 	if err != nil {
 		rt.t.Fatal(err)
 	}
@@ -243,7 +242,7 @@ func (rt *RepoTester) GetTagsList(w http.ResponseWriter, r *http.Request, name s
 	// Get oci manifest from testdata folder
 	tagsListFileName := fmt.Sprintf("%s-oci-tags-list.json", name)
 	tagsListFile := filepath.Join(testdataPath, tagsListFileName)
-	tagsList, err := ioutil.ReadFile(tagsListFile)
+	tagsList, err := os.ReadFile(tagsListFile)
 	if err != nil {
 		rt.t.Fatal(err)
 	}
@@ -274,7 +273,7 @@ func (rt *RepoTester) GetChartPackage(w http.ResponseWriter, r *http.Request, na
 	testdataPath := path.Join(path.Dir(filename), "../../../../testdata/oci")
 	// Get chart from testdata folder
 	chartPackageFile := path.Join(testdataPath, "charts", chartPackageName)
-	chartPackage, err := ioutil.ReadFile(chartPackageFile)
+	chartPackage, err := os.ReadFile(chartPackageFile)
 	if err != nil {
 		rt.t.Fatal(err)
 	}

--- a/pkg/syncer/fakesyncer.go
+++ b/pkg/syncer/fakesyncer.go
@@ -1,7 +1,6 @@
 package syncer
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -40,14 +39,14 @@ func NewFake(t *testing.T, opts ...FakeSyncerOption) *Syncer {
 		o(sopts)
 	}
 
-	srcTmp, err := ioutil.TempDir("", "charts-syncer-tests-src-fake")
+	srcTmp, err := os.MkdirTemp("", "charts-syncer-tests-src-fake")
 	if err != nil {
 		t.Fatalf("error creating temporary folder: %v", err)
 	}
 	t.Cleanup(func() { os.RemoveAll(srcTmp) })
 
 	if sopts.Destination == "" {
-		dstTmp, err := ioutil.TempDir("", "charts-syncer-tests-dst-fake")
+		dstTmp, err := os.MkdirTemp("", "charts-syncer-tests-dst-fake")
 		if err != nil {
 			t.Fatalf("error creating temporary folder: %v", err)
 		}
@@ -63,13 +62,13 @@ func NewFake(t *testing.T, opts ...FakeSyncerOption) *Syncer {
 		t.Fatalf("error listing tgz files: %v", err)
 	}
 	for _, sourceFile := range matches {
-		input, err := ioutil.ReadFile(sourceFile)
+		input, err := os.ReadFile(sourceFile)
 		if err != nil {
 			t.Fatalf("error reading %q chart: %v", sourceFile, err)
 		}
 
 		dstFile := path.Join(srcTmp, filepath.Base(sourceFile))
-		if err = ioutil.WriteFile(dstFile, input, 0644); err != nil {
+		if err = os.WriteFile(dstFile, input, 0644); err != nil {
 			t.Fatalf("error copying chart to %q: %v", dstFile, err)
 		}
 	}

--- a/pkg/syncer/sync.go
+++ b/pkg/syncer/sync.go
@@ -2,7 +2,6 @@ package syncer
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -55,7 +54,7 @@ func (s *Syncer) SyncPendingCharts(names ...string) error {
 		klog.Infof("Syncing %q chart...", id)
 
 		klog.V(3).Infof("Processing %q chart...", id)
-		outdir, err := ioutil.TempDir("", "charts-syncer")
+		outdir, err := os.MkdirTemp("", "charts-syncer")
 		if err != nil {
 			klog.Errorf("unable to create output directory for %q chart: %+v", id, err)
 			errs = multierror.Append(errs, errors.Trace(err))
@@ -65,7 +64,7 @@ func (s *Syncer) SyncPendingCharts(names ...string) error {
 
 		hasDeps := len(ch.Dependencies) > 0
 
-		workdir, err := ioutil.TempDir("", "charts-syncer")
+		workdir, err := os.MkdirTemp("", "charts-syncer")
 		if err != nil {
 			klog.Errorf("unable to create work directory for %q chart: %+v", id, err)
 			errs = multierror.Append(errs, errors.Trace(err))
@@ -156,7 +155,7 @@ func (s *Syncer) SyncWithChartsSyncer(ch *Chart, id, workdir, outdir string, has
 
 	// Read final chart metadata
 	configFilePath := fmt.Sprintf("%s/Chart.yaml", chartPath)
-	chartConfig, err := ioutil.ReadFile(configFilePath)
+	chartConfig, err := os.ReadFile(configFilePath)
 	if err != nil {
 		klog.Errorf("unable to read %q metadata: %+v", id, err)
 		return "", errors.Trace(err)

--- a/pkg/syncer/sync_test.go
+++ b/pkg/syncer/sync_test.go
@@ -3,7 +3,6 @@ package syncer_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -64,7 +63,7 @@ func TestFakeSyncPendingCharts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			dstTmp, err := ioutil.TempDir("", "charts-syncer-tests-dst-fake")
+			dstTmp, err := os.MkdirTemp("", "charts-syncer-tests-dst-fake")
 			if err != nil {
 				t.Fatalf("error creating temporary folder: %v", err)
 			}
@@ -314,7 +313,7 @@ func TestSyncPendingChartsChartMuseum(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			// Create temp folder and copy index.yaml
-			dstTmp, err := ioutil.TempDir("", "charts-syncer-tests-index-fake")
+			dstTmp, err := os.MkdirTemp("", "charts-syncer-tests-index-fake")
 			if err != nil {
 				t.Fatalf("error creating temporary folder: %v", err)
 			}
@@ -329,12 +328,12 @@ func TestSyncPendingChartsChartMuseum(t *testing.T) {
 			tTester := repo.NewClientTester(t, tc.targetRepo.GetRepo(), true, "")
 
 			// Replace placeholder URL with source url
-			index, err := ioutil.ReadFile(dstIndex)
+			index, err := os.ReadFile(dstIndex)
 			if err != nil {
 				t.Fatal(err)
 			}
 			newContents := strings.Replace(string(index), "TEST_PLACEHOLDER", fmt.Sprintf("%s%s", sTester.GetURL(), "/charts"), -1)
-			if err = ioutil.WriteFile(dstIndex, []byte(newContents), 0); err != nil {
+			if err = os.WriteFile(dstIndex, []byte(newContents), 0); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
When I was creating the other PR my IDE complained about the ioutil pkg being deprecated.
> Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code. See the specific function documentation for details.

Looked at the [docs](https://pkg.go.dev/os) and all them simply call an other function from the `os` or `io` pkg. Replicated the deprecated functions with their newer equivalent.